### PR TITLE
fix: storyblok 'asset' field compatibility (DOP-97)

### DIFF
--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -155,7 +155,8 @@ export const BlogSEO = ({
     description: summary,
   };
 
-  const twImageUrl = featuredImages[0].url;
+  // Storyblok has deprecated 'Image' block & its newer 'Asset' block
+  const twImageUrl = featuredImages[0].url.split(/https:/)[1] ?? featuredImages[0].url;
 
   return (
     <>

--- a/pages/articles/[...slug].tsx
+++ b/pages/articles/[...slug].tsx
@@ -40,9 +40,16 @@ export async function getStaticProps({ params, preview = false }: any) {
 export default function Blog({ post }: any) {
   const { title, summary, image, author, markdown } = post.content;
 
+  const imageUrl = typeof image === 'object' ? image.filename : image;
+
   return (
     <>
-      <BlogSEO title={title} summary={summary} date={post?.first_published_at} images={[image]} />
+      <BlogSEO
+        title={title}
+        summary={summary}
+        date={post?.first_published_at}
+        images={[imageUrl]}
+      />
       <div className="mt-24 mx-auto">
         {post.content.draft ? (
           <>
@@ -63,7 +70,7 @@ export default function Blog({ post }: any) {
             title={title}
             summary={summary}
             date={post.first_published_at}
-            image={image}
+            image={imageUrl}
             markdown={markdown}
             tag_list={post.tag_list}
             authors={author}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,7 @@ export async function getStaticProps(context: any) {
   };
 }
 
-type Story = StoryData<{ title: string; summary: string; image: string }>;
+type Story = StoryData<{ title: string; summary: string; image: any }>;
 
 interface HomeProps {
   stories: {
@@ -156,13 +156,14 @@ export default function Home({ stories }: HomeProps) {
           >
             {displayedStories?.map((frontMatter: Story, index: number) => {
               const { title, summary, image } = frontMatter.content;
+              const imageUrl = typeof image === 'object' ? image.filename : image;
               const { full_slug, first_published_at } = frontMatter;
               return (
                 <li key={index} className="py-6">
                   <article>
                     <div className="space-y-2 xl:grid xl:grid-cols-6 gap-3 xl:space-y-0">
                       <Link href={`/${full_slug}`} className={'col-span-2 xl:mr-5'}>
-                        <img src={image} className="sm:w-full rounded-md" alt={title} />
+                        <img src={imageUrl} className="sm:w-full rounded-md" alt={title} />
                       </Link>
                       <div className="space-y-5 xl:col-span-4">
                         <div className="space-y-1">

--- a/pages/zh/articles/[...slug].tsx
+++ b/pages/zh/articles/[...slug].tsx
@@ -40,9 +40,16 @@ export async function getStaticProps({ params, preview = false }: any) {
 export default function Blog({ post }: any) {
   const { title, summary, image, author, markdown } = post.content;
 
+  const imageUrl = typeof image === 'object' ? image.filename : image;
+
   return (
     <>
-      <BlogSEO title={title} summary={summary} date={post?.first_published_at} images={[image]} />
+      <BlogSEO
+        title={title}
+        summary={summary}
+        date={post?.first_published_at}
+        images={[imageUrl]}
+      />
       <div className="mt-24 mx-auto">
         {post.content.draft ? (
           <>
@@ -63,7 +70,7 @@ export default function Blog({ post }: any) {
             title={title}
             summary={summary}
             date={post.first_published_at}
-            image={image}
+            image={imageUrl}
             markdown={markdown}
             tag_list={post.tag_list}
             authors={author}


### PR DESCRIPTION
Our older articles used Storyblok's 'Image' field which has been deprecated. Our newer articles use the 'Asset' field iwhich has a different string format. This messes up how twitter webcrawlers read preview image urls. 